### PR TITLE
Avoid losing the stack context + support non-strings

### DIFF
--- a/console.emoji.js
+++ b/console.emoji.js
@@ -18,7 +18,7 @@ const commands = [
 
 {
     // Create custom commands
-    commands.forEach(({ name, emoji }) => window.console[name] = (...args) => console.log(emoji + ' ' + args.join(', ')));
+    commands.forEach(({ name, emoji }) => window.console[name] = console.log.bind(console, emoji));
 }
 
 // Log to the console!

--- a/console.emoji.js
+++ b/console.emoji.js
@@ -9,17 +9,10 @@
  */
 
 // Define your custom commands and emoji
-const commands = [
-    { emoji: '🦄', name: 'unicorn' },
-    { emoji: '🍕', name: 'pizza' },
-    { emoji: '🍺', name: 'beer' },
-    { emoji: '💩', name: 'poo' }
-];
-
-{
-    // Create custom commands
-    commands.forEach(({ name, emoji }) => window.console[name] = console.log.bind(console, emoji));
-}
+console.unicorn = console.log.bind(console, '🦄');
+console.pizza = console.log.bind(console, '🍕');
+console.beer = console.log.bind(console, '🍺');
+console.poo = console.log.bind(console, '💩');
 
 // Log to the console!
 console.unicorn("Magical!");


### PR DESCRIPTION
`() => console.log` moves the line number in the console (losing the context of where it was originally called)

`console.log` supports multiple arguments, automatically separated by a space, with any kind of type. `args.join(', ')` only outputs strings,